### PR TITLE
Coreutils tests arm

### DIFF
--- a/pkgs/development/libraries/gnutls/default.nix
+++ b/pkgs/development/libraries/gnutls/default.nix
@@ -34,7 +34,10 @@ stdenv.mkDerivation {
 
   patches = [ ./nix-ssl-cert-file.patch ]
     # Disable native add_system_trust.
-    ++ lib.optional (isDarwin && !withSecurity) ./no-security-framework.patch;
+    ++ lib.optional (isDarwin && !withSecurity) ./no-security-framework.patch
+    # fix gnulib tests on 32-bit ARM. Included on gnutls master.
+    # https://lists.gnu.org/r/bug-gnulib/2020-08/msg00225.html
+    ++ lib.optional stdenv.hostPlatform.isAarch32 ./fix-gnulib-tests-arm.patch;
 
   # Skip some tests:
   #  - pkgconfig: building against the result won't work before installing (3.5.11)

--- a/pkgs/development/libraries/gnutls/fix-gnulib-tests-arm.patch
+++ b/pkgs/development/libraries/gnutls/fix-gnulib-tests-arm.patch
@@ -1,0 +1,45 @@
+>From 175e0bc72808d564074c4adcc72aeadb74adfcc6 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Thu, 27 Aug 2020 17:52:58 -0700
+Subject: [PATCH] perror, strerror_r: remove unportable tests
+
+Problem reported by Florian Weimer in:
+https://lists.gnu.org/r/bug-gnulib/2020-08/msg00220.html
+* tests/test-perror2.c (main):
+* tests/test-strerror_r.c (main): Omit unportable tests.
+---
+ tests/test-perror2.c    | 3 ---
+ tests/test-strerror_r.c | 3 ---
+ 2 files changed, 6 deletions(-)
+
+diff --git a/gl/tests/test-perror2.c b/gl/tests/test-perror2.c
+index 1d14eda7b..c6214dd25 100644
+--- a/gl/tests/test-perror2.c
++++ b/gl/tests/test-perror2.c
+@@ -79,9 +79,6 @@ main (void)
+     errno = -5;
+     perror ("");
+     ASSERT (!ferror (stderr));
+-    ASSERT (msg1 == msg2 || msg1 == msg4 || STREQ (msg1, str1));
+-    ASSERT (msg2 == msg4 || STREQ (msg2, str2));
+-    ASSERT (msg3 == msg4 || STREQ (msg3, str3));
+     ASSERT (STREQ (msg4, str4));
+ 
+     free (str1);
+diff --git a/gl/tests/test-strerror_r.c b/gl/tests/test-strerror_r.c
+index b11d6fd9f..c1dbcf837 100644
+--- a/gl/tests/test-strerror_r.c
++++ b/gl/tests/test-strerror_r.c
+@@ -165,9 +165,6 @@ main (void)
+ 
+     strerror_r (EACCES, buf, sizeof buf);
+     strerror_r (-5, buf, sizeof buf);
+-    ASSERT (msg1 == msg2 || msg1 == msg4 || STREQ (msg1, str1));
+-    ASSERT (msg2 == msg4 || STREQ (msg2, str2));
+-    ASSERT (msg3 == msg4 || STREQ (msg3, str3));
+     ASSERT (STREQ (msg4, str4));
+ 
+     free (str1);
+-- 
+2.17.1
+

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -31,7 +31,10 @@ stdenv.mkDerivation (rec {
 
   patches = optional stdenv.hostPlatform.isCygwin ./coreutils-8.23-4.cygwin.patch
     # included on coreutils master; TODO: apply unconditionally, I guess
-    ++ optional stdenv.hostPlatform.isAarch64 ./sys-getdents-undeclared.patch;
+    ++ optional stdenv.hostPlatform.isAarch64 ./sys-getdents-undeclared.patch
+    # fix gnulib tests on 32-bit ARM. Included on coreutils master.
+    # https://lists.gnu.org/r/bug-gnulib/2020-08/msg00225.html
+    ++ optional stdenv.hostPlatform.isAarch32 ./fix-gnulib-tests-arm.patch;
 
   postPatch = ''
     # The test tends to fail on btrfs,f2fs and maybe other unusual filesystems.

--- a/pkgs/tools/misc/coreutils/fix-gnulib-tests-arm.patch
+++ b/pkgs/tools/misc/coreutils/fix-gnulib-tests-arm.patch
@@ -1,0 +1,45 @@
+>From 175e0bc72808d564074c4adcc72aeadb74adfcc6 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Thu, 27 Aug 2020 17:52:58 -0700
+Subject: [PATCH] perror, strerror_r: remove unportable tests
+
+Problem reported by Florian Weimer in:
+https://lists.gnu.org/r/bug-gnulib/2020-08/msg00220.html
+* tests/test-perror2.c (main):
+* tests/test-strerror_r.c (main): Omit unportable tests.
+---
+ tests/test-perror2.c    | 3 ---
+ tests/test-strerror_r.c | 3 ---
+ 2 files changed, 6 deletions(-)
+
+diff --git a/gnulib-tests/test-perror2.c b/gnulib-tests/test-perror2.c
+index 1d14eda7b..c6214dd25 100644
+--- a/gnulib-tests/test-perror2.c
++++ b/gnulib-tests/test-perror2.c
+@@ -79,9 +79,6 @@ main (void)
+     errno = -5;
+     perror ("");
+     ASSERT (!ferror (stderr));
+-    ASSERT (msg1 == msg2 || msg1 == msg4 || STREQ (msg1, str1));
+-    ASSERT (msg2 == msg4 || STREQ (msg2, str2));
+-    ASSERT (msg3 == msg4 || STREQ (msg3, str3));
+     ASSERT (STREQ (msg4, str4));
+ 
+     free (str1);
+diff --git a/gnulib-tests/test-strerror_r.c b/gnulib-tests/test-strerror_r.c
+index b11d6fd9f..c1dbcf837 100644
+--- a/gnulib-tests/test-strerror_r.c
++++ b/gnulib-tests/test-strerror_r.c
+@@ -165,9 +165,6 @@ main (void)
+ 
+     strerror_r (EACCES, buf, sizeof buf);
+     strerror_r (-5, buf, sizeof buf);
+-    ASSERT (msg1 == msg2 || msg1 == msg4 || STREQ (msg1, str1));
+-    ASSERT (msg2 == msg4 || STREQ (msg2, str2));
+-    ASSERT (msg3 == msg4 || STREQ (msg3, str3));
+     ASSERT (STREQ (msg4, str4));
+ 
+     free (str1);
+-- 
+2.17.1
+

--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -20,9 +20,10 @@ stdenv.mkDerivation rec {
     substituteInPlace xargs/xargs.c --replace 'char default_cmd[] = "echo";' 'char default_cmd[] = "${coreutils}/bin/echo";'
   '';
 
-  patches = [
-    ./no-install-statedir.patch
-  ];
+  patches = [ ./no-install-statedir.patch ]
+    # fix gnulib tests on 32-bit ARM. Included on findutils master.
+    # https://lists.gnu.org/r/bug-gnulib/2020-08/msg00225.html
+    ++ stdenv.lib.optional stdenv.hostPlatform.isAarch32 ./fix-gnulib-tests-arm.patch;
 
   buildInputs = [ coreutils ]; # bin/updatedb script needs to call sort
 

--- a/pkgs/tools/misc/findutils/fix-gnulib-tests-arm.patch
+++ b/pkgs/tools/misc/findutils/fix-gnulib-tests-arm.patch
@@ -1,0 +1,45 @@
+>From 175e0bc72808d564074c4adcc72aeadb74adfcc6 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Thu, 27 Aug 2020 17:52:58 -0700
+Subject: [PATCH] perror, strerror_r: remove unportable tests
+
+Problem reported by Florian Weimer in:
+https://lists.gnu.org/r/bug-gnulib/2020-08/msg00220.html
+* tests/test-perror2.c (main):
+* tests/test-strerror_r.c (main): Omit unportable tests.
+---
+ tests/test-perror2.c    | 3 ---
+ tests/test-strerror_r.c | 3 ---
+ 2 files changed, 6 deletions(-)
+
+diff --git a/gnulib-tests/test-perror2.c b/gnulib-tests/test-perror2.c
+index 1d14eda7b..c6214dd25 100644
+--- a/gnulib-tests/test-perror2.c
++++ b/gnulib-tests/test-perror2.c
+@@ -79,9 +79,6 @@ main (void)
+     errno = -5;
+     perror ("");
+     ASSERT (!ferror (stderr));
+-    ASSERT (msg1 == msg2 || msg1 == msg4 || STREQ (msg1, str1));
+-    ASSERT (msg2 == msg4 || STREQ (msg2, str2));
+-    ASSERT (msg3 == msg4 || STREQ (msg3, str3));
+     ASSERT (STREQ (msg4, str4));
+ 
+     free (str1);
+diff --git a/gnulib-tests/test-strerror_r.c b/gnulib-tests/test-strerror_r.c
+index b11d6fd9f..c1dbcf837 100644
+--- a/gnulib-tests/test-strerror_r.c
++++ b/gnulib-tests/test-strerror_r.c
+@@ -165,9 +165,6 @@ main (void)
+ 
+     strerror_r (EACCES, buf, sizeof buf);
+     strerror_r (-5, buf, sizeof buf);
+-    ASSERT (msg1 == msg2 || msg1 == msg4 || STREQ (msg1, str1));
+-    ASSERT (msg2 == msg4 || STREQ (msg2, str2));
+-    ASSERT (msg3 == msg4 || STREQ (msg3, str3));
+     ASSERT (STREQ (msg4, str4));
+ 
+     free (str1);
+-- 
+2.17.1
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
